### PR TITLE
Fix long names on drawer

### DIFF
--- a/packages/app/App.tsx
+++ b/packages/app/App.tsx
@@ -177,6 +177,8 @@ export default class App extends Component<{}, AppComponentState> {
         await this.refreshScheduleIfNeeded();
         this.updateDayScheduleIfNeeded();
 
+        store.dispatch(setUserInfo({ name: 'Bruh Bruh Bruh Bruh' }));
+
         const { dates: { semesterOneStart } } = store.getState();
         if (semesterOneStart !== null) {
           const freshmenDay = subDays(semesterOneStart, 1);

--- a/packages/app/ios/WHS.xcodeproj/xcshareddata/xcschemes/WHS.xcscheme
+++ b/packages/app/ios/WHS.xcodeproj/xcshareddata/xcschemes/WHS.xcscheme
@@ -84,9 +84,9 @@
       </AdditionalOptions>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Release"
-      selectedDebuggerIdentifier = ""
-      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/packages/app/src/components/common/Navbar.tsx
+++ b/packages/app/src/components/common/Navbar.tsx
@@ -49,9 +49,10 @@ interface NavbarProps {
 }
 
 export default function Navbar(props: NavbarProps & NavigationScreenProps<NavigationParams, any>) {
+  const hitSlop = { top: 15, left: 15, bottom: 15, right: 15 };
   return (
     <NavbarContainer>
-      <HamburgerContainer onPress={props.navigation.openDrawer}>
+      <HamburgerContainer onPress={props.navigation.openDrawer} hitSlop={hitSlop}>
         <One />
         <Two />
         <Three />

--- a/packages/app/src/components/drawer/Profile.tsx
+++ b/packages/app/src/components/drawer/Profile.tsx
@@ -24,6 +24,7 @@ const ImageContainer = styled.View`
 `;
 
 const RightContainer = styled.View`
+  flex-shrink: 1;
   margin-left: ${PROFILE_INFO_MARGIN_LEFT};
 `;
 


### PR DESCRIPTION
Add flex-shrink to shrink names in drawer and hitslop for navbar. Fixes #15 and #16. 