### PR TITLE
Fix Wednesday UI that mistaken starts on mod 2

### DIFF
--- a/packages/app/src/components/schedule/ScheduleCard.tsx
+++ b/packages/app/src/components/schedule/ScheduleCard.tsx
@@ -118,8 +118,9 @@ const makeCardDayScheduleSelector = () => createSelector(
     const isFinals = scheduleType === 'FINALS';
 
     const revisedUserDaySchedule = injectAssemblyOrFinalsIfNeeded(schedule, scheduleType, day);
-    // Remove homeroom/no homeroom item on wednesday schedules
-    const userDaySchedule = revisedUserDaySchedule.slice(scheduleType === 'WEDNESDAY' ? 1 : 0);
+    // PATCH: scheduleType === 'WEDNESDAY' && day !== 3 condition is needed since the first item is already
+    // sliced off for normal Wednesday schedules (i.e. day === 3, see interpolateOpenMods)
+    const userDaySchedule = revisedUserDaySchedule.slice(scheduleType === 'WEDNESDAY' && day !== 3 ? 1 : 0);
 
     const cardDaySchedule = daySchedule.map(([start, end, modNumber]) => {
       const startTime = formatTime(start);

--- a/packages/app/src/utils/bugsnag.ts
+++ b/packages/app/src/utils/bugsnag.ts
@@ -29,7 +29,7 @@ function serializeState(state: AppState): IMetadata {
 }
 
 const config = new Configuration();
-config.codeBundleId = '3.0.1-b6';
+config.codeBundleId = '3.0.1-b7';
 config.notifyReleaseStages = ['production'];
 config.registerBeforeSendCallback((report) => {
   const state = store.getState();


### PR DESCRIPTION
Fixes regression introduced in #35. Regular Wednesdays (not non-Wednesdays with Wednesday-like schedules) are sliced twice, leading to the schedule card starting on mod 2.