### PR TITLE
Fix regressions from e-learning update

### DIFF
--- a/packages/app/src/screens/Dashboard.tsx
+++ b/packages/app/src/screens/Dashboard.tsx
@@ -29,7 +29,7 @@ const scheduleSelector = createSelector(
   (schedule, dayScheduleType, elearningPlans) => {
     const { scheduleDay } = getScheduleDay(new Date(), elearningPlans);
     if (['BREAK', 'SUMMER', 'WEEKEND'].includes(dayScheduleType)) {
-      return schedule[scheduleDay];
+      return []; // NOTE: this might be a regression, since before entire schedule was returned. See getDashboardInfo for details
     }
     return injectAssemblyOrFinalsIfNeeded(schedule[scheduleDay], dayScheduleType, scheduleDay);
   },

--- a/packages/app/src/utils/bugsnag.ts
+++ b/packages/app/src/utils/bugsnag.ts
@@ -29,7 +29,7 @@ function serializeState(state: AppState): IMetadata {
 }
 
 const config = new Configuration();
-config.codeBundleId = '3.0.1-b9';
+config.codeBundleId = '3.0.1-b10';
 config.notifyReleaseStages = ['production'];
 config.registerBeforeSendCallback((report) => {
   const state = store.getState();

--- a/packages/app/src/utils/dashboard-info.ts
+++ b/packages/app/src/utils/dashboard-info.ts
@@ -71,10 +71,7 @@ export function getDashboardInfo(
   userDaySchedule: UserDaySchedule,
   { current }: ScheduleInfo,
 ): DashboardInfoGetter[] {
-  if (userDaySchedule.length === 0) {
-    return [scheduleEmptyInfo];
-  }
-
+  // Handle these cases first
   switch (daySchedule) {
     case SCHEDULES.BREAK:
       return [breakInfo];
@@ -82,6 +79,10 @@ export function getDashboardInfo(
       return [weekendInfo];
     case SCHEDULES.SUMMER:
       return [summerInfo];
+  }
+
+  if (userDaySchedule.length === 0) {
+    return [scheduleEmptyInfo];
   }
 
   switch (current) {

--- a/packages/app/src/utils/query-schedule.ts
+++ b/packages/app/src/utils/query-schedule.ts
@@ -215,6 +215,11 @@ export function getScheduleTypeOnDate(
     return 'BREAK';
   }
 
+  const calendarDay = queryDate.getDay() - 1; // this is duplicate code, but weekend should take precedence over elearning
+  if (calendarDay > 4 || calendarDay < 0) {
+    return 'WEEKEND';
+  }
+
   const currentPlan = getPlanOnDate(queryDate, elearningPlans);
   if (currentPlan !== undefined) {
     return 'REGULAR';
@@ -234,8 +239,6 @@ export function getScheduleDay(
   elearningPlans: ELearningPlansState,
 ): { scheduleDay: number; calendarDay: number } {
   const calendarDay = queryDate.getDay() - 1;
-  const clone = new Date(queryDate.getTime()); // avoid mutation...
-  clone.setHours(0, 0, 0, 0);
 
   /**
    * In completely online (red) or completely in person (green) the days proceeds as normal


### PR DESCRIPTION
Fixes undefined error on weekends. This line:

https://github.com/Li357/WHS/blob/8cdda334be4b1b02e7b180d58942d787aff52ca0/packages/app/src/screens/Dashboard.tsx#L32

would return undefined for weekends since `scheduleDay` is either -1 or 5 on weekends, out of range for schedule. Corrected by returning empty array on weekends, then handling weekends/breaks first in `getDashboardInfo` so weekend is not confused with users with empty schedules.

Also, fixes so that weekends have precedence over elearning plans.